### PR TITLE
Hash passwords

### DIFF
--- a/firebase.php
+++ b/firebase.php
@@ -40,10 +40,15 @@ function verifyPassword(&$firebase, $username, $password) {
     $hash = strval(
             $firebase->get('Logins/' . $username . '/password'));
     $hash = trim($hash, '"');
+    if(stripper($hash) == $password && password_needs_rehash($hash, PASSWORD_DEFAULT)){ // if pasword is stored as plaintext
+        $firebase->set("Logins/$username/password", password_hash($password, PASSWORD_DEFAULT));
+        return true;
+    }
+
     if(password_verify(strval($password), $hash)) {
         if(password_needs_rehash($hash, PASSWORD_DEFAULT)){
             $hash = password_hash($password, PASSWORD_DEFAULT);
-            $firebase->set("Logins/$username/password", $hash);
+            $firebase->set("Logins/$username/password", $hash); // update password if the cost is too low ==> too easy to break
         }
         return true;
     }else {

--- a/firebase.php
+++ b/firebase.php
@@ -41,6 +41,10 @@ function verifyPassword(&$firebase, $username, $password) {
             $firebase->get('Logins/' . $username . '/password'));
     $hash = trim($hash, '"');
     if(password_verify(strval($password), $hash)) {
+        if(password_needs_rehash($hash, PASSWORD_DEFAULT)){
+            $hash = password_hash($password, PASSWORD_DEFAULT);
+            $firebase->set("Logins/$username/password", $hash);
+        }
         return true;
     }else {
         return false;

--- a/firebase.php
+++ b/firebase.php
@@ -7,9 +7,12 @@ function stripper($string ){//is nosql injection a thing? Do we need this?
 }
 
 function createAccount($username, $password, $userid, &$firebase) {
+    // https://www.php.net/manual/en/function.password-hash.php
+    $hash = password_hash($password, PASSWORD_DEFAULT);
+    echo $hash;
     $user = [
         'username' => $username,
-        'password' => $password,
+        'password' => $hash,
         'userid' => $userid
     ];
     $firebase->set('Logins/' . $username, $user);
@@ -34,7 +37,10 @@ function genid() {
 }
 
 function verifyPassword(&$firebase, $username, $password) {
-    if(stripper(strval($firebase->get('Logins/' . $username . '/password'))) == strval($password)) {
+    $hash = strval(
+            $firebase->get('Logins/' . $username . '/password'));
+    $hash = trim($hash, '"');
+    if(password_verify(strval($password), $hash)) {
         return true;
     }else {
         return false;


### PR DESCRIPTION
Uses `password_hash` to hash passwords. If a password is stored as plain text, it will match the inputted password directly and update the hash in firebase. 