### PR TITLE
Fixed Kicking Invalid Users

### DIFF
--- a/home.php
+++ b/home.php
@@ -6,7 +6,7 @@ include_once('includes.php');
 $firebase = new \Firebase\FirebaseLib(DEFAULT_URL, DEFAULT_TOKEN);
 session_start();
 $user = stripper($_SESSION["user"]);
-if($user == "invalid") {
+if($user == "invalid" || !isset($user) || $user == "") {
     header("Location: index.php");
 }
 ?>


### PR DESCRIPTION
Session only searched for 'invalid' before now checks isset and ""